### PR TITLE
use webpack 4

### DIFF
--- a/Template.ProcessCube.Project/apps/Template.ProcessCube.Project/Dockerfile
+++ b/Template.ProcessCube.Project/apps/Template.ProcessCube.Project/Dockerfile
@@ -1,13 +1,13 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 RUN apt-get -q update && \
-  curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+  curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
   apt-get install -y \
   nodejs
 
 WORKDIR /apps/Template.ProcessCube.Project/frontend
 COPY apps/Template.ProcessCube.Project/frontend/package.json apps/Template.ProcessCube.Project/frontend/package-lock.json ./
-RUN npm ci
+RUN npm i
 
 WORKDIR /
 COPY ../../analyzers.ruleset .

--- a/Template.ProcessCube.Project/apps/Template.ProcessCube.Project/frontend/package.json
+++ b/Template.ProcessCube.Project/apps/Template.ProcessCube.Project/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "18.x"
+    "node": "16.x"
   },
   "dependencies": {
     "@atlas-engine-contrib/atlas-ui_sdk": "^3.0.0",
@@ -13,7 +13,7 @@
     "http-proxy-middleware": "2.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "^5.0.1",
+    "react-scripts": "^4.0.3",
     "reactstrap": "^9.1.5",
     "rimraf": "4.1.2"
   },
@@ -22,18 +22,12 @@
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.10",
     "@types/react-router-dom": "^5.3.3",
-    "eslint": "8.34.0",
-    "eslint-config-react-app": "7.0.1",
-    "eslint-plugin-flowtype": "8.0.3",
+    "eslint-config-react-app": "6.0.0",
     "eslint-plugin-import": "2.27.5",
     "eslint-plugin-import-newlines": "^1.3.0",
     "eslint-plugin-jsx-a11y": "6.7.1",
     "eslint-plugin-react": "7.32.2",
-    "typescript": "^4.9.4",
-    "@svgr/webpack": "^6.5.1"
-  },
-  "overrides": {
-    "@svgr/webpack": "$@svgr/webpack"
+    "typescript": "^4.9.4"
   },
   "scripts": {
     "start": "rimraf ./build && react-scripts start",

--- a/TemplateHandler.csproj
+++ b/TemplateHandler.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>2.3.0</PackageVersion>
+    <PackageVersion>2.3.1</PackageVersion>
     <PackageId>Template.ProcessCube.Project</PackageId>
     <Title>Project Template</Title>
     <Authors>Jeremy Hill, David Wehmeyer</Authors>


### PR DESCRIPTION
## Changes

- Node 18 -> Node 16: [reason](https://stackoverflow.com/questions/69665222/node-js-17-0-1-gatsby-error-digital-envelope-routinesunsupported-err-os)
- use "react-scripts": "^4.0.3" -> implicitly uses webpack v. 4.x.x
- adjust eslint versions to match new react-scripts version

## Tasks

[factro](https://cloud.factro.com/5681c8b0/?p=task&pi=6994b847-3d46-4573-8105-55eea9fa4c51)

PR: #25
